### PR TITLE
观星扩展限制参数

### DIFF
--- a/lua/server/room.lua
+++ b/lua/server/room.lua
@@ -1317,8 +1317,13 @@ function Room:askForGuanxing(player, cards, top_limit, bottom_limit)
   local top, bottom
   if result ~= "" then
     local d = json.decode(result)
-    top = d[1] or {}
-    bottom = d[2] or {}
+    if #top_limit > 0 and top_limit[1] == 0 then
+      top = {}
+      bottom = d[1]
+    else
+      top = d[1]
+      bottom = d[2]
+    end
   else
     top = cards
     bottom = {}

--- a/qml/Pages/RoomElement/GuanxingBox.qml
+++ b/qml/Pages/RoomElement/GuanxingBox.qml
@@ -9,6 +9,7 @@ GraphicsBox {
   property var cards: []
   property var result: []
   property var areaCapacities: []
+  property var areaLimits: []
   property var areaNames: []
   property int padding: 25
 
@@ -56,6 +57,7 @@ GraphicsBox {
 
     MetroButton {
       Layout.alignment: Qt.AlignHCenter
+      id: buttonConfirm
       text: Backend.translate("OK")
       width: 120
       height: 35
@@ -83,8 +85,9 @@ GraphicsBox {
   function arrangeCards() {
     result = new Array(areaCapacities.length);
     let i;
-    for (i = 0; i < result.length; i++)
+    for (i = 0; i < result.length; i++){
       result[i] = [];
+    }
 
     let card, j, area, cards, stay;
     for (i = 0; i < cardItem.count; i++) {
@@ -101,12 +104,20 @@ GraphicsBox {
         }
       }
 
-      if (stay)
-        result[0].push(card);
+      if (stay) {
+        if (result[0].length >= areaCapacities[0]) {
+          result[1].push(card);
+        } else {
+          result[0].push(card);
+        }
+      }
     }
-
     for(i = 0; i < result.length; i++)
       result[i].sort((a, b) => a.x - b.x);
+
+
+    console.log(result[0]);
+    console.log(result[1]);
 
     let box, pos, pile;
     for (j = 0; j < areaRepeater.count; j++) {
@@ -114,11 +125,23 @@ GraphicsBox {
       for (i = 0; i < result[j].length; i++) {
         box = pile.cardRepeater.itemAt(i);
         pos = mapFromItem(pile, box.x, box.y);
+        console.log(pile);
+        console.log(pile.x+","+pile.y);
+        console.log(box);
+        console.log(pos);
         card = result[j][i];
         card.origX = pos.x;
         card.origY = pos.y;
         card.goBack(true);
       }
+    }
+
+    for (i = 0; i < areaRepeater.count; i++) {
+      if (result[i].length < areaLimits[i]) {
+        buttonConfirm.enabled = false;
+        break;
+      }
+      buttonConfirm.enabled = true;
     }
   }
 

--- a/qml/Pages/RoomElement/GuanxingBox.qml
+++ b/qml/Pages/RoomElement/GuanxingBox.qml
@@ -116,19 +116,16 @@ GraphicsBox {
       result[i].sort((a, b) => a.x - b.x);
 
 
-    console.log(result[0]);
-    console.log(result[1]);
 
     let box, pos, pile;
     for (j = 0; j < areaRepeater.count; j++) {
       pile = areaRepeater.itemAt(j);
+      if (pile.y === 0){
+        pile.y = j * 150
+      }
       for (i = 0; i < result[j].length; i++) {
         box = pile.cardRepeater.itemAt(i);
         pos = mapFromItem(pile, box.x, box.y);
-        console.log(pile);
-        console.log(pile.x+","+pile.y);
-        console.log(box);
-        console.log(pos);
         card = result[j][i];
         card.origX = pos.x;
         card.origY = pos.y;

--- a/qml/Pages/RoomLogic.js
+++ b/qml/Pages/RoomLogic.js
@@ -604,7 +604,10 @@ callbacks["AskForSkillInvoke"] = function(jsonData) {
 callbacks["AskForGuanxing"] = function(jsonData) {
   let data = JSON.parse(jsonData);
   let cards = [];
-
+  let min_top_cards = data.min_top_cards;
+  let max_top_cards = data.max_top_cards;
+  let min_bottom_cards = data.min_bottom_cards;
+  let max_bottom_cards = data.max_bottom_cards;
   roomScene.state = "replying";
   roomScene.popupBox.source = "RoomElement/GuanxingBox.qml";
   data.cards.forEach(id => {
@@ -612,7 +615,8 @@ callbacks["AskForGuanxing"] = function(jsonData) {
     cards.push(JSON.parse(d));
   });
   let box = roomScene.popupBox.item;
-  box.areaCapacities = [cards.length, cards.length];
+  box.areaCapacities = [max_top_cards, max_bottom_cards];
+  box.areaLimits = [min_top_cards, min_bottom_cards];
   box.areaNames = ["Top", "Bottom"];
   box.cards = cards;
   box.arrangeCards();

--- a/qml/Pages/RoomLogic.js
+++ b/qml/Pages/RoomLogic.js
@@ -615,9 +615,15 @@ callbacks["AskForGuanxing"] = function(jsonData) {
     cards.push(JSON.parse(d));
   });
   let box = roomScene.popupBox.item;
-  box.areaCapacities = [max_top_cards, max_bottom_cards];
-  box.areaLimits = [min_top_cards, min_bottom_cards];
-  box.areaNames = ["Top", "Bottom"];
+  if (max_top_cards == 0) {
+    box.areaCapacities = [max_bottom_cards];
+    box.areaLimits = [min_bottom_cards];
+    box.areaNames = ["Bottom"];
+  } else {
+    box.areaCapacities = [max_top_cards, max_bottom_cards];
+    box.areaLimits = [min_top_cards, min_bottom_cards];
+    box.areaNames = ["Top", "Bottom"];
+  }
   box.cards = cards;
   box.arrangeCards();
   box.accepted.connect(() => {


### PR DESCRIPTION
已知Bug：~~初始化时，若牌堆顶牌位不足，剩余的牌在图像上会置于牌堆顶位置而不是牌堆底。挪动一次牌后恢复正常~~
更新：已修复