### PR TITLE
Fixbug

### DIFF
--- a/lua/core/skill_type/view_as.lua
+++ b/lua/core/skill_type/view_as.lua
@@ -27,12 +27,12 @@ end
 
 ---@param player Player
 function ViewAsSkill:enabledAtPlay(player)
-  return true
+  return player:hasSkill(self)
 end
 
 ---@param player Player
 function ViewAsSkill:enabledAtResponse(player)
-  return true
+  return player:hasSkill(self)
 end
 
 return ViewAsSkill

--- a/lua/server/events/hp.lua
+++ b/lua/server/events/hp.lua
@@ -151,7 +151,7 @@ GameEvent.functions[GameEvent.Damage] = function(self)
   stages = {
     {fk.Damage, damageStruct.from},
     {fk.Damaged, damageStruct.to},
-    {fk.DamageFinished, damageStruct.from},
+    {fk.DamageFinished, damageStruct.to},
   }
 
   for _, struct in ipairs(stages) do

--- a/lua/server/serverplayer.lua
+++ b/lua/server/serverplayer.lua
@@ -478,6 +478,7 @@ function ServerPlayer:bury()
   self:throwAllCards()
   self:throwAllMarks()
   self:clearPiles()
+  self:setChainState(false)
 end
 
 function ServerPlayer:throwAllCards(flag)

--- a/lua/server/serverplayer.lua
+++ b/lua/server/serverplayer.lua
@@ -479,6 +479,7 @@ function ServerPlayer:bury()
   self:throwAllMarks()
   self:clearPiles()
   self:setChainState(false)
+  if not self.faceup then self:turnOver() end
 end
 
 function ServerPlayer:throwAllCards(flag)

--- a/packages/maneuvering/init.lua
+++ b/packages/maneuvering/init.lua
@@ -497,7 +497,7 @@ Fk:loadTranslationTable{
   ["fire_attack_skill"] = "火攻",
 	[":fire_attack"] = "锦囊牌<br /><b>时机</b>：出牌阶段<br /><b>目标</b>：一名有手牌的角色<br /><b>效果</b>：目标角色展示一张手牌，然后你可以弃置一张与所展示牌花色相同的手牌令其受到1点火焰伤害。",
   ["#fire_attack-show"] = "%src 对你使用了火攻，请展示一张手牌",
-  ["#fire_attack-discard"] = "你可弃置一张 %arg 手牌，对 %src 造成1点伤害",
+  ["#fire_attack-discard"] = "你可弃置一张 %arg 手牌，对 %src 造成1点火属性伤害",
   ["supply_shortage"] = "兵粮寸断",
 	[":supply_shortage"] = "延时锦囊牌<br /><b>时机</b>：出牌阶段<br /><b>目标</b>：距离1的一名其他角色<br /><b>效果</b>：将此牌置于目标角色判定区内。其判定阶段进行判定：若结果不为梅花，其跳过摸牌阶段。然后将【兵粮寸断】置入弃牌堆。",
   ["guding_blade"] = "古锭刀",

--- a/packages/maneuvering/init.lua
+++ b/packages/maneuvering/init.lua
@@ -251,12 +251,12 @@ local fireAttackSkill = fk.CreateActiveSkill{
     local to = room:getPlayerById(cardEffectEvent.to)
     if to:isKongcheng() then return end
 
-    local showCard = room:askForCard(to, 1, 1, false, self.name, false)[1]
+    local showCard = room:askForCard(to, 1, 1, false, self.name, false, nil, "#fire_attack-show:" .. from.id)[1]
     to:showCards(showCard)
 
     showCard = Fk:getCardById(showCard)
     local cards = room:askForDiscard(from, 1, 1, false, self.name, true,
-                                    ".|.|" .. showCard:getSuitString())
+                                    ".|.|" .. showCard:getSuitString(), "#fire_attack-discard:" .. to.id .. "::" .. showCard:getSuitString())
     if #cards > 0 then
       room:damage({
         from = from,
@@ -496,6 +496,8 @@ Fk:loadTranslationTable{
   ["fire_attack"] = "火攻",
   ["fire_attack_skill"] = "火攻",
 	[":fire_attack"] = "锦囊牌<br /><b>时机</b>：出牌阶段<br /><b>目标</b>：一名有手牌的角色<br /><b>效果</b>：目标角色展示一张手牌，然后你可以弃置一张与所展示牌花色相同的手牌令其受到1点火焰伤害。",
+  ["#fire_attack-show"] = "%src 对你使用了火攻，请展示一张手牌",
+  ["#fire_attack-discard"] = "你可弃置一张 %arg 手牌，对 %src 造成1点伤害",
   ["supply_shortage"] = "兵粮寸断",
 	[":supply_shortage"] = "延时锦囊牌<br /><b>时机</b>：出牌阶段<br /><b>目标</b>：距离1的一名其他角色<br /><b>效果</b>：将此牌置于目标角色判定区内。其判定阶段进行判定：若结果不为梅花，其跳过摸牌阶段。然后将【兵粮寸断】置入弃牌堆。",
   ["guding_blade"] = "古锭刀",

--- a/packages/standard_cards/init.lua
+++ b/packages/standard_cards/init.lua
@@ -1103,7 +1103,7 @@ local eightDiagramSkill = fk.CreateTriggerSkill{
   events = {fk.AskForCardUse, fk.AskForCardResponse},
   can_trigger = function(self, event, target, player, data)
     return target == player and player:hasSkill(self.name) and
-      (data.cardName == "jink" or (data.pattern and string.find(data.pattern, "jink")))
+      (data.cardName == "jink" or (data.pattern and Exppattern:Parse(data.pattern):matchExp("jink|0|nosuit|none")))
   end,
   on_use = function(self, event, target, player, data)
     local room = player.room

--- a/packages/standard_cards/init.lua
+++ b/packages/standard_cards/init.lua
@@ -1103,7 +1103,7 @@ local eightDiagramSkill = fk.CreateTriggerSkill{
   events = {fk.AskForCardUse, fk.AskForCardResponse},
   can_trigger = function(self, event, target, player, data)
     return target == player and player:hasSkill(self.name) and
-      (data.cardName == "jink" or (data.pattern and Exppattern:Parse(data.pattern):matchExp("jink|0|nosuit|none")))
+      (data.cardName == "jink" or (data.pattern and string.find(data.pattern, "jink")))
   end,
   on_use = function(self, event, target, player, data)
     local room = player.room


### PR DESCRIPTION
将DamageFinished承载者改为受到伤害的角色（解决无来源伤害无法传导的bug）
bury加入重置武将牌
改进火攻的交互
更改八卦阵的pattern（解决AskForUseCard和AskForResponseCard的pattern为任意时八卦阵可以响应的bug）